### PR TITLE
Add OnNfcDisabledListener

### DIFF
--- a/android/src/main/java/nordpol/OnNfcDisabledListener
+++ b/android/src/main/java/nordpol/OnNfcDisabledListener
@@ -1,0 +1,3 @@
+public interface OnNfcDisabledListener {
+    public void nfcDisabled();
+}


### PR DESCRIPTION
This interface is to be used with TagDispatcher, providing a callback to deal with the case where NFC functionality should be enabled by the user.

@petter-fidesmo 
@slomo 