### PR TITLE
Add method to get card historical bytes (if any)

### DIFF
--- a/core/src/main/java/nordpol/IsoCard.java
+++ b/core/src/main/java/nordpol/IsoCard.java
@@ -14,4 +14,5 @@ public interface IsoCard {
     public void setTimeout(int timeout);
     public byte[] transceive(byte[] data) throws IOException;
     public List<byte[]> transceive(List<byte[]> data) throws IOException;
+    public byte[] getHistoricalBytes() throws IOException;
 }


### PR DESCRIPTION
getHistoricalBytes() is a useful method for debugging/diagnostics, and is already defined in android.nfc.Tag, so we should make use of it where possible.