### PR TITLE
Make travis home env optional

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,11 @@
+val credentialsFile = sys.env.get("TRAVIS_BUILD_DIR").map { path =>
+  Seq(bintrayCredentialsFile := Path(path) / ".bintray")
+} getOrElse(Seq())
+
 val baseSettings = BaseProject.metaSettings ++ BaseProject.scalaSettings ++
   BaseProject.scalariformSettings ++ BaseProject.releaseSettings ++
-  Seq(
+  credentialsFile ++ Seq(
     publishMavenStyle := true,
-    bintrayCredentialsFile := Path(sys.env.get("TRAVIS_BUILD_DIR").get) / ".bintray",
     bintrayOrganization := Some("fidesmo"),
     bintrayPackageLabels := Seq("android", "nfc"),
     licenses += ("MIT", url("http://opensource.org/licenses/MIT"))


### PR DESCRIPTION
- This is only required for bintray deploy and prevents building locally