### PR TITLE
Attempt to detect and discard misbehaving devices

### DIFF
--- a/android/src/main/java/nordpol/AndroidCard.java
+++ b/android/src/main/java/nordpol/AndroidCard.java
@@ -22,17 +22,10 @@ public class AndroidCard implements IsoCard {
         this.card = card;
     }
 
-    public static AndroidCard get(Tag tag) throws IOException {
+    public static AndroidCard get(Tag tag) {
         IsoDep card = IsoDep.get(tag);
 
         if(card != null) {
-            /* Workaround for the Samsung Galaxy S5 (since the
-             * first connection always hangs on transceive).
-             * TODO: This could be improved if we could identify
-             * Samsung Galaxy S5 devices
-             */
-            card.connect();
-            card.close();
             return new AndroidCard(card);
         } else {
             return null;


### PR DESCRIPTION
- Try to detect failing ISO compatible devices by sending a SELECT
  command
- If failing, discard the tag rather than dispatching it