### PR TITLE
Discover NFC type B chips

### DIFF
--- a/android/src/main/java/nordpol/TagDispatcher.java
+++ b/android/src/main/java/nordpol/TagDispatcher.java
@@ -339,7 +339,7 @@ public class TagDispatcher {
                     dispatchTag(tag);
                 }
             };
-        int flags = NfcAdapter.FLAG_READER_NFC_A;
+        int flags = NfcAdapter.FLAG_READER_NFC_A | NfcAdapter.FLAG_READER_NFC_B;
         if(disableSounds) {
             flags = flags | NfcAdapter.FLAG_READER_NO_PLATFORM_SOUNDS;
         }


### PR DESCRIPTION
This PR solves the bug found with Android devices that are have certain NFC characteristics that make it hard or even impossible to discover chips as NFC type A. By adding NFC type B chips to the allowed filter we now check for all IsoDep cards (https://developer.android.com/reference/android/nfc/tech/IsoDep.html "Tags that enumerate the IsoDep technology in getTechList() will also enumerate NfcA or NfcB (since IsoDep builds on top of either of these).") which is exactly what ALL Fidesmo devices are as well as Type A. The main problem arose when using certain devices, mainly the S7 with DESfire cards. Now they are easier to find and deliver to.